### PR TITLE
Unset CHECK50_ID and CHECK50_TOKEN before running student checks

### DIFF
--- a/check50-wrapper
+++ b/check50-wrapper
@@ -15,7 +15,7 @@ tag_sha=$(git commit-tree HEAD^{tree} -m "$tag_name")
 git push origin $tag_sha:refs/tags/$tag_name
 
 # get check50 results
-check50_results=$(check50 --local --debug $CHECK50_BRANCH)
+check50_results=$(unset CHECK50_TOKEN CHECK50_ID; check50 --local --debug $CHECK50_BRANCH)
 if [ $? -ne 0 ]; then
     check50_results=[]
 fi


### PR DESCRIPTION
Leaving this in allows student code to access our Github auth token and post their own scores to cs50.me.