### PR TITLE
fixed awscli and awsebcli dependency conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN apt-get update && \
 
 # Install Python packages
 RUN pip install \
-    awscli \
     awsebcli \
+    awscli \
     help50 \
     render50 \
     submit50

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ RUN apt-get update && \
 # Install Python packages
 RUN pip install \
     awsebcli \
-    awscli \
+    awscli `# must come after awsebcli to ensure supported version` \
     help50 \
     render50 \
     submit50


### PR DESCRIPTION
This way, `awsebcli` should install its strictly required version of `colorama` first which would satisfy `awscli` as well.