### PR TITLE
Build push patch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,29 +15,46 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build for linux/amd64 and push
+      - name: Build for linux/amd64
         uses: docker/build-push-action@v2
         with:
           build-args: |
             VCS_REF=${{ github.sha }}
+          load: true
           platforms: linux/amd64
-          tags: cs50/cli:${{ github.sha }},cs50/cli:latest
+          tags: cs50/cli:${{ github.sha }}-amd64,cs50/cli:latest
           cache-from: type=registry,ref=cs50/cli:buildcache
           cache-to: type=registry,ref=cs50/cli:buildcache,mode=max
-          if: ${{ github.ref == 'refs/heads/main' }}
-          push: true
 
-      - name: Build for linux/arm64 and push
+      - name: Push linux/amd64 build to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker push cs50/cli:${{ github.sha }}-amd64
+          docker push cs50/cli:latest
+
+      - name: Build for linux/arm64
         uses: docker/build-push-action@v2
         with:
           build-args: |
             VCS_REF=${{ github.sha }}
+          load: true
           platforms: linux/arm64
-          tags: cs50/cli:${{ github.sha }},cs50/cli:latest
+          tags: cs50/cli:${{ github.sha }}-arm64
           cache-from: type=registry,ref=cs50/cli:buildcache
           cache-to: type=registry,ref=cs50/cli:buildcache,mode=max
-          if: ${{ github.ref == 'refs/heads/main' }}
-          push: true
+
+      - name: Push linux/arm64 build to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker push cs50/cli:${{ github.sha }}-arm64
+
+      - name: Create multi-arch manifest and push to Docker Hub
+        if: ${{ github.ref == 'refs/heads/main' }}
+        run: |
+          docker manifest create cs50/cli:latest \
+          --amend cs50/cli:${{ github.sha }}-amd64 \
+          --amend cs50/cli:${{ github.sha }}-arm64
+          docker manifest push cs50/cli:latest
 
       - name: Re-deploy depdendents
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      - name: Build and push
+      - name: Build for linux/amd64 and push
         uses: docker/build-push-action@v2
         with:
           build-args: |
             VCS_REF=${{ github.sha }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
+          tags: cs50/cli:${{ github.sha }},cs50/cli:latest
+          cache-from: type=registry,ref=cs50/cli:buildcache
+          cache-to: type=registry,ref=cs50/cli:buildcache,mode=max
+          if: ${{ github.ref == 'refs/heads/main' }}
+          push: true
+
+      - name: Build for linux/arm64 and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            VCS_REF=${{ github.sha }}
+          platforms: linux/arm64
           tags: cs50/cli:${{ github.sha }},cs50/cli:latest
           cache-from: type=registry,ref=cs50/cli:buildcache
           cache-to: type=registry,ref=cs50/cli:buildcache,mode=max

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,14 +22,14 @@ jobs:
             VCS_REF=${{ github.sha }}
           load: true
           platforms: linux/amd64
-          tags: cs50/cli:${{ github.sha }}-amd64,cs50/cli:latest
+          tags: cs50/cli:amd64,cs50/cli:latest
           cache-from: type=registry,ref=cs50/cli:buildcache
           cache-to: type=registry,ref=cs50/cli:buildcache,mode=max
 
       - name: Push linux/amd64 build to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          docker push cs50/cli:${{ github.sha }}-amd64
+          docker push cs50/cli:amd64
           docker push cs50/cli:latest
 
       - name: Build for linux/arm64
@@ -39,21 +39,21 @@ jobs:
             VCS_REF=${{ github.sha }}
           load: true
           platforms: linux/arm64
-          tags: cs50/cli:${{ github.sha }}-arm64
+          tags: cs50/cli:arm64
           cache-from: type=registry,ref=cs50/cli:buildcache
           cache-to: type=registry,ref=cs50/cli:buildcache,mode=max
 
       - name: Push linux/arm64 build to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
-          docker push cs50/cli:${{ github.sha }}-arm64
+          docker push cs50/cli:arm64
 
       - name: Create multi-arch manifest and push to Docker Hub
         if: ${{ github.ref == 'refs/heads/main' }}
         run: |
           docker manifest create cs50/cli:latest \
-          --amend cs50/cli:${{ github.sha }}-amd64 \
-          --amend cs50/cli:${{ github.sha }}-arm64
+          --amend cs50/cli:amd64 \
+          --amend cs50/cli:arm64
           docker manifest push cs50/cli:latest
 
       - name: Re-deploy depdendents


### PR DESCRIPTION
Currently, we are able to build and push docker images supporting both amd64 and arm64 platforms to docker hub, but the build process for linux/arm64 was taking way too much time (about 3.5 hours) compared to linux/amd64 (~20mins). Probably because of arm64 emulation in a x86_64 vm:
[https://github.com/uraimo/run-on-arch-action/issues/4](https://github.com/uraimo/run-on-arch-action/issues/4)

Since most of our services are still based on the linux/amd64 image, it might make more sense to build and push the linux/amd64 version right away. Once the linux/arm64 build is finished, we will update the docker manifest so cs50/cli:latest will be referencing both images.

This way, we might be able to iterate faster for other services while waiting for the linux/arm64 build to finish.