### PR TITLE
removed EXPOSE as unnecessary, since cli50 can --expose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG VCS_REF
 
 
-# Expose ports
-EXPOSE 5000 8080 8081 8082
-
-
 # Avoid "delaying package configuration, since apt-utils is not installed"
 RUN apt update && apt install --yes apt-utils
 


### PR DESCRIPTION
Any concerns with this change for IDE or Codespaces? `cs50/server` already `EXPOSE`s a port explicitly, https://github.com/cs50/server/blob/main/Dockerfile#L6. And looks like `cs50/codespace` doesn't need to, https://github.com/cs50/codespace/blob/main/Dockerfile?

This way, default ports can be moved to `cli50` alone rather than maintain in parallel, https://github.com/cs50/cli50/blob/main/cli50/__main__.py#L27-L31. And user can now override exposed ports via `cli50` with `--port`.