### PR TITLE
Added compile50

### DIFF
--- a/opt/cs50/bin/compile50
+++ b/opt/cs50/bin/compile50
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+file="$1"
+make=$(which make)
+makeFile=""
+
+args=("$@")
+
+parameters="${args[*]:1}"
+
+if [ -z "$file" ]; then
+    echo "compile50 /path/to/file.c <cli arguments>"
+    exit
+fi
+
+absolute=$(realpath "$file")
+
+if [[ "$absolute" == *.c ]]
+then
+    if [ -f "$absolute" ]; then
+        makeFile=$(echo "$absolute" | tr --delete .c)
+        $make "$makeFile" && "$makeFile" $parameters && rm -f "$makeFile"
+    else
+        echo "$f was not found :("
+    fi
+else
+    echo "File extension is not .c :/"
+fi


### PR DESCRIPTION
`compile50` is a bash script to simplify the process of compiling C code via the make utility

It is capable of taking the file containing C code, compiling it, running it, and finally deleting the binary

Along with that, it is able to accept command-line arguments from the user and pass those when running the binary

For example, if there were a script named `name.c` which would print the user's name by taking it from the 1st command-line argument, you would use compile50 as follows:

```bash
~/ $ compile50 name.c arav
Hello arav
```
***