### PR TITLE
Improve readability of CFLAGS

### DIFF
--- a/etc/profile.d/cli.sh
+++ b/etc/profile.d/cli.sh
@@ -46,7 +46,11 @@ if [ "$(whoami)" != "root" ]; then
 
     # Make
     export CC="clang"
-    export CFLAGS="-ferror-limit=1 -gdwarf-4 -ggdb3 -O0 -std=c11 -Wall -Werror -Wextra -Wno-gnu-folding-constant -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wshadow"
+    CFLAGS="-ferror-limit=1 -gdwarf-4 -ggdb3 -O0 -std=c11 "
+    CFLAGS+="-Wall -Werror -Wextra "
+    CFLAGS+="-Wno-gnu-folding-constant -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable "
+    CFLAGS+="-Wshadow"
+    export CFLAGS
     export LDLIBS="-lcrypt -lcs50 -lm"
 
     # Manual sections to search


### PR DESCRIPTION
<!-- Confirmed success via `echo $CFLAGS` on local `bash, version 5.1.16(1)-release (x86_64-pc-msys)` -->

<!--

highlighted in golden yellow are the commands incrementally defining "CFLAGS"

<img width="960" alt="cflags improve readability wezterm-gui_0XKzXqtepc" src="https://user-images.githubusercontent.com/19423063/186873755-8cfd4864-f6d3-45dd-96a5-00c58c41bb9a.png"> -->