### PR TITLE
Add -q to python alias

### DIFF
--- a/etc/profile.d/cli.sh
+++ b/etc/profile.d/cli.sh
@@ -23,6 +23,7 @@ if [ "$(whoami)" != "root" ]; then
     alias ls="ls --color -F --ignore=lost+found" # Add trailing slashes
     alias mv="mv -i"
     alias pip="pip --no-cache-dir"
+    alias python="python -q"
     alias rm="rm -i"
     alias sudo="sudo " # Trailing space enables elevated command to be an alias
 


### PR DESCRIPTION
"don't print version and copyright messages on interactive startup"