### PR TITLE
Add "entr" package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,7 @@ RUN curl https://packagecloud.io/install/repositories/cs50/repo/script.deb.sh | 
         cowsay \
         dos2unix \
         dnsutils `# For nslookup` \
+        entr `# For automatically running commands on file change` \
         fonts-noto-color-emoji `# For render50` \
         gdb \
         git \


### PR DESCRIPTION
With `entr`, one can automatically run commands on file changes. It can be used e.g. to watch a C source file and then run `style50` and `make` on it. This makes it possible to edit the file in one tmux pane, and have the another pane next to it where `style50` and `make` automatically run whenever the source file is saved.

In my setup, I edit the source file in one tmux pane (in my own environment, without `cli50`), and in the right pane, within `cli50` I can do this:

`export TARGET=readability; echo ${TARGET}.c | entr -cs 'style50 ${TARGET}.c && make --trace $TARGET'`

That way I can always see an updated style and build status based on the latest saved file state, without even leaving the editor pane. A clean output might look like this:

``` bash
Results generated by style50 v2.7.5
Looks good!
<builtin>: update target 'readability' due to: readability.c
clang -ferror-limit=1 -gdwarf-4 -ggdb3 -O0 -std=c11 -Wall -Werror -Wextra -Wno-gnu-folding-constant -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-but-set-variable -Wshadow    readability.c  -lcrypt -lcs50 -lm -o readability
sh returned exit code 0
```

When I install `entr` in `cli50`, it reports the installed size as 53.2 kB, so I'd say it's a small package compared to its usefulness.