### PR TITLE
Removes `gh`, `weasyprint` (but installs latter's dependencies instead); copies all of `/usr` from builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,9 +109,8 @@ FROM ubuntu:22.04
 LABEL maintainer="sysadmins@cs50.harvard.edu"
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY --from=builder /usr/bin/ /usr/bin/
-COPY --from=builder /usr/local/ /usr/local/
-COPY --from=builder /opt/ /opt/
+COPY --from=builder /usr /usr
+COPY --from=builder /opt /opt
 
 # Avoid "delaying package configuration, since apt-utils is not installed"
 RUN apt update && \
@@ -147,33 +146,33 @@ RUN curl https://packagecloud.io/install/repositories/cs50/repo/script.deb.sh | 
     apt install --no-install-recommends --yes \
         astyle \
         bash-completion \
-        build-essential `# libc, gcc, g++, make, dpkg-dev etc.`\
+        build-essential  `# dpkg-dev, libc, gcc, g++, make, etc.`\
         clang \
-        coreutils `# For fold` \
+        coreutils  `# For fold` \
         cowsay \
         dos2unix \
-        dnsutils `# For nslookup` \
-        fonts-noto-color-emoji `# For render50` \
+        dnsutils  `# For nslookup` \
+        fonts-noto-color-emoji  `# For render50` \
         gdb \
         git \
         git-lfs \
         jq \
         less \
-        libcs50 `# CS50 library` \
-        libmagic-dev `# For style50` \
-        libyaml-0-2 `# Runtime package for gem` \
+        libcs50 \
+        libmagic-dev  `# For style50` \
+        libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0  `# For render50` \
+        libyaml-0-2  `# Runtime package for gem` \
         man \
         man-db \
         nano \
-        openssh-client `# For ssh-keygen` \
-        psmisc `# For fuser` \
-        ruby-dev `# Ruby development headers` \
+        openssh-client  `# For ssh-keygen` \
+        psmisc  `# For fuser` \
+        ruby-dev  `# Ruby development headers` \
         sudo \
-        tzdata `# For TZ` \
+        tzdata  `# For TZ` \
         unzip \
         valgrind \
         vim \
-        weasyprint `# For render50` \
         zip && \
         apt clean && \
     pip3 install --no-cache-dir \

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,30 +146,30 @@ RUN curl https://packagecloud.io/install/repositories/cs50/repo/script.deb.sh | 
     apt install --no-install-recommends --yes \
         astyle \
         bash-completion \
-        build-essential  `# dpkg-dev, libc, gcc, g++, make, etc.`\
+        build-essential `# dpkg-dev, libc, gcc, g++, make, etc.`\
         clang \
-        coreutils  `# For fold` \
+        coreutils `# For fold` \
         cowsay \
         dos2unix \
-        dnsutils  `# For nslookup` \
-        fonts-noto-color-emoji  `# For render50` \
+        dnsutils `# For nslookup` \
+        fonts-noto-color-emoji `# For render50` \
         gdb \
         git \
         git-lfs \
         jq \
         less \
         libcs50 \
-        libmagic-dev  `# For style50` \
-        libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0  `# For render50` \
-        libyaml-0-2  `# Runtime package for gem` \
+        libmagic-dev `# For style50` \
+        libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 `# For render50` \
+        libyaml-0-2 `# Runtime package for gem` \
         man \
         man-db \
         nano \
-        openssh-client  `# For ssh-keygen` \
-        psmisc  `# For fuser` \
-        ruby-dev  `# Ruby development headers` \
+        openssh-client `# For ssh-keygen` \
+        psmisc `# For fuser` \
+        ruby-dev `# Ruby development headers` \
         sudo \
-        tzdata  `# For TZ` \
+        tzdata `# For TZ` \
         unzip \
         valgrind \
         vim \


### PR DESCRIPTION
```
$ docker image ls cs50/cli
REPOSITORY   TAG       IMAGE ID       CREATED          SIZE
cs50/cli     latest    9e5ee9408afb   17 minutes ago   3.17GB
```

https://doc.courtbouillon.org/weasyprint/stable/first_steps.html#ubuntu-20-04