### PR TITLE
removed `http-server.patch` as unnecessary in `cs50/cli`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -202,12 +202,10 @@ RUN npm install --global \
 
 
 # Patch index.js in http-server
-COPY http-server.patch index.js.patch /tmp
+COPY index.js.patch /tmp
 RUN cd /usr/local/lib/node_modules/http-server/lib/core/show-dir && \
     patch index.js < /tmp/index.js.patch && \
-    cd /usr/local/lib/node_modules/http-server/bin && \
-    patch http-server < /tmp/http-server.patch && \
-    rm --force /tmp/http-server.patch /tmp/index.js.patch
+    rm --force /tmp/index.js.patch
 
 
 # Copy files to image

--- a/http-server.patch
+++ b/http-server.patch
@@ -1,5 +1,0 @@
-# diff /usr/local/lib/node_modules/http-server/bin/http-server http-server > http-server.patch
-208c208
-<     logger.info([chalk.yellow('\nhttp-server version: '), chalk.cyan(require('../package.json').version)].join(''));
----
->     //logger.info([chalk.yellow('\nhttp-server version: '), chalk.cyan(require('../package.json').version)].join(''));


### PR DESCRIPTION
We use a bash wrapper function in cs50/codespace to remove versions from command-line output where possible.