### PR TITLE
only COPYing `/usr/local`, removing version from jdk dir (so as not to have to update `JAVA_HOME`)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -192,6 +192,7 @@ RUN curl https://packagecloud.io/install/repositories/cs50/repo/script.deb.sh | 
         unzip \
         valgrind \
         vim \
+        wget \
         zip && \
         apt clean && \
     pip3 install --no-cache-dir \

--- a/etc/profile.d/cli.sh
+++ b/etc/profile.d/cli.sh
@@ -40,7 +40,7 @@ if [ "$(whoami)" != "root" ]; then
     export PROMPT_COMMAND='history -a' # Store Bash History Immediately
 
     # Java
-    export JAVA_HOME="/opt/jdk-21.0.1"
+    export JAVA_HOME="/opt/jdk"
 
     # Make
     export CC="clang"


### PR DESCRIPTION
Seems to reduce image size from 3GB to 2.3GB:

```
$ docker images | grep cs50/cli
cs50/cli           latest    4e3aeb837b8c   3 minutes ago    2.3GB

$ make run
~/ $ python --version
Python 3.11.7
~/ $ ruby --version
ruby 3.2.2 (2023-03-30 revision e51014f9c0) [aarch64-linux]
~/ $ node --version
v21.5.0
~/ $ sqlite3 --version
3.44.2 2023-11-24 11:41:44 ebead0e7230cd33bcec9f95d2183069565b9e709bf745c9b5db65cc0cbf92c0f (64-bit)
```