### PR TITLE
enh(make): Use `--debug=why` option ...

### DIFF
--- a/opt/cs50/bin/make
+++ b/opt/cs50/bin/make
@@ -19,5 +19,5 @@ if [[ -d "$1" ]]; then
     echo "$1 is a directory"
     exit 1
 else
-    /usr/bin/make -B -s $*
+    /usr/bin/make -B -s --debug=why $*
 fi


### PR DESCRIPTION
  * This shows a very succinct output of the output (target) and source (dep) file
  * This option was added in GNU Make in v4.4

Closes: https://github.com/cs50/cli/issues/215

----
the force push to main kinda messed things up somehow.
i will fix these after ongoing exams.
update: i have fixed those.  

<!-- 
`git rebase --interactive main` 

change the origin to point to upstream/main, rather than just main.. .that might help in some cases.
-->

<img src="https://github.com/cs50/cli/assets/19423063/787d8f1d-8b82-4870-9f0e-905e33684a60" width=500px />

<img src="https://github.com/cs50/cli/assets/19423063/7ea53e27-3496-4208-877e-a9c4758777e9" width=500px />
