### PR TITLE
Use Ubuntu 24.04 Runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ on: push
 
 jobs:
   build-amd64:
-    runs-on: ubuntu-latest-64-cores
+    runs-on: ubuntu-2404-64-cores-amd
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,26 +42,8 @@ jobs:
           docker push cs50/cli:canary-amd64
 
   build-arm64:
-    runs-on: ubuntu-latest-64-cores-arm
+    runs-on: ubuntu-2404-64-cores-arm
     steps:
-      - name: Install Docker (remove once Docker is pre-installed on arm64 runners)
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt update
-          sudo apt install -y ca-certificates curl
-          sudo install -m 0755 -d /etc/apt/keyrings
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update
-          sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          sudo usermod -aG docker $USER
-          sudo apt install -y acl
-          sudo setfacl --modify user:$USER:rw /var/run/docker.sock
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -71,9 +53,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install Python (replace with setup-python once available on arm64 runners)
-        run: |
-          sudo apt install -y python3
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
       - name: Build for linux/arm64
         uses: docker/build-push-action@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Build for linux/amd64
         uses: docker/build-push-action@v5
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Build for linux/arm64
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Migrate to using Ubuntu 24.04 Amd64 and Arm64 runners for GitHub actions. Fixes #223.